### PR TITLE
added statement "gi.require_version(..)" - this is needed before Gtk imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+/build/
+/udev-discover
+/udevdiscover/

--- a/udev-discover.in
+++ b/udev-discover.in
@@ -22,6 +22,11 @@
 ###
 
 import sys
+
+# (http://mednis.info/use-girequire_versiongtk-30-before-import.html)
+import gi
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gtk, Gdk
 from gi.repository import GObject
 import logging

--- a/udevdiscover/device/__init__.py
+++ b/udevdiscover/device/__init__.py
@@ -22,6 +22,9 @@
 # Authors : J. Félix Ontañón <fontanon@emergya.es>
 # 
 
+# (http://mednis.info/use-girequire_versiongtk-30-before-import.html)
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import GUdev
 
 def match_string(device, search_string):

--- a/udevdiscover/devicefinder.py
+++ b/udevdiscover/devicefinder.py
@@ -22,6 +22,9 @@
 # Authors : J. Félix Ontañón <fontanon@emergya.es>
 # 
 
+# (http://mednis.info/use-girequire_versiongtk-30-before-import.html)
+import gi
+gi.require_version("GUdev", "1.0")
 from gi.repository import GObject
 from gi.repository import GUdev
 import device 

--- a/udevdiscover/utils.py
+++ b/udevdiscover/utils.py
@@ -22,6 +22,9 @@
 
 import exceptions
 import types
+# (http://mednis.info/use-girequire_versiongtk-30-before-import.html)
+import gi
+gi.require_version("GConf", "2.0")
 from gi.repository import GConf
 
 class GConfKeysDict(dict):


### PR DESCRIPTION
This fixes error messages like this in current GTK environments:

/usr/bin/udev-discover:25: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.

See http://mednis.info/use-girequire_versiongtk-30-before-import.html
